### PR TITLE
Centered login and join inputs

### DIFF
--- a/src/components/Pages/Join.js
+++ b/src/components/Pages/Join.js
@@ -80,7 +80,7 @@ class RegistrationForm extends React.Component {
     };
 
     return (
-      <div>
+      <div style={{display: 'flex', justifyContent: 'center'}}>
       <Form onSubmit={this.handleSubmit}>
         <FormItem
           {...formItemLayout}

--- a/src/components/Pages/Login.js
+++ b/src/components/Pages/Login.js
@@ -19,6 +19,7 @@ class LoginForm extends React.Component {
   render() {
     const { getFieldDecorator } = this.props.form;
     return (
+    <div style={{display: 'flex', justifyContent: 'center'}}>
       <Form onSubmit={this.handleSubmit} className="login-form">
 
         <FormItem>
@@ -53,6 +54,7 @@ class LoginForm extends React.Component {
           Or <a href="./Join">Join Now!</a>
         </FormItem>
       </Form>
+	</div>
     );
   }
 }


### PR DESCRIPTION
Centers input boxes in Join.js and Login.js. There needs to be a change in Join.js for the text to not over lap, but I can fix that.