### PR TITLE
Persisting app state across reloads

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,10 +23,19 @@ import {Plan} from './components/Pages/Plan';
 import {Experience} from './components/Pages/Experience';
 import {Connect} from './components/Pages/Connect';
 
-import models from './models/user.js';
+import models from './models/user';
+import { loadState, saveState } from './models/localStorage';
+
+// dva hook method triggers when app state changes
+const onStateChange = (info) => {  
+  saveState(info);
+}
 
 // Create dva app
-export const app = dva();
+export const app = dva({
+  initialState: loadState(),
+  onStateChange: onStateChange,
+});
 
 // Create model
 app.model(models);

--- a/src/models/localStorage.js
+++ b/src/models/localStorage.js
@@ -1,0 +1,21 @@
+export const loadState = () => {
+    try {
+        const serializedState = localStorage.getItem('state');
+        if (serializedState === null) {
+            return undefined;
+        }
+        return JSON.parse(serializedState);
+    } catch (err) {
+        return undefined;
+    }
+};
+
+export const saveState = (state) => {
+    try {
+        const serializedState = JSON.stringify(state);
+        localStorage.setItem('state', serializedState);
+    } catch (err) {
+        // Todo: Log error
+        console.log("Error saving state",err);
+    }
+}


### PR DESCRIPTION
I didn't have to change much to persist the state. Fortunately dva has hook methods like onStateChange, that is called everytime the state is changed. So using that along with Dan Abramov's functions for saving and loading state made it simple. Also the initial state of the app is set to whatever was saved last in localstorage. Unfortunately now we cannot log out, so I will add that as another issue that needs to be solved.