### PR TITLE
Inspiration user db migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 /config/config.js
+/config/dbMigrationConfig.json
 .DS_Store
 .env.local
 .env.development.local

--- a/config/dbMigrationConfig.json.template
+++ b/config/dbMigrationConfig.json.template
@@ -1,0 +1,27 @@
+
+{
+  "development": {
+    "username": "root",
+    "password": "root",
+    "database": "travelhive_development_db",
+    "host": "localhost",
+    "dialect": "mysql",
+    "port": "3306"
+  },
+  "test": {
+    "username": "root",
+    "password": "root",
+    "database": "travelhive_test_db",
+    "host": "localhost",
+    "dialect": "mysql",
+    "port": "3306"
+  },
+  "production": {
+    "username": "root",
+    "password": "root",
+    "database": "travelhive_production_db",
+    "host": "localhost",
+    "dialect": "mysql",
+    "port": "3306"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.0.17",
-    "sequelize": "^4.28.6"
+    "sequelize": "^4.28.6",
+    "sequelize-cli": "^3.2.0"
   },
   "scripts": {
     "start": "cross-env react-scripts start",

--- a/server/.sequelizerc
+++ b/server/.sequelizerc
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = {
+  'config': path.resolve('../config/', 'dbMigrationConfig.json'),
+  
+}
+
+

--- a/server/migrations/20180212183911-create-inspiration.js
+++ b/server/migrations/20180212183911-create-inspiration.js
@@ -8,6 +8,10 @@ module.exports = {
         type:Sequelize.UUID,
         default: Sequelize.UUIDV4
       },     
+      userId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+      },   
       image: {
         type: Sequelize.TEXT
       },

--- a/server/migrations/20180212183911-create-inspiration.js
+++ b/server/migrations/20180212183911-create-inspiration.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Inspirations', {      
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type:Sequelize.UUID,
+        default: Sequelize.UUIDV4
+      },     
+      image: {
+        type: Sequelize.TEXT
+      },
+      description: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Inspirations');
+  }
+};

--- a/server/migrations/20180213070811-update-user.js
+++ b/server/migrations/20180213070811-update-user.js
@@ -5,12 +5,7 @@ module.exports = {
       await queryInterface.changeColumn('Users', 'profileImg', {        
         type: Sequelize.TEXT('medium'),
         allowNull: true,        
-      }),
-      
-      await queryInterface.changeColumn('Users','id', {
-        type: Sequelize.UUID,
-        default: Sequelize.UUIDV4
-      }),
+      }),      
       
     ]
     
@@ -20,12 +15,7 @@ module.exports = {
       await queryInterface.changeColumn('Users', 'profileImg', {        
         type: Sequelize.BLOB(),
         allowNull: true,
-      }),
-
-      await queryInterface.changeColumn('Users', 'id', {
-        type: Sequelize.INTEGER,
-        autoincrement: true
-      }),
+      }),     
            
     ]  
   }    

--- a/server/migrations/20180213070811-update-user.js
+++ b/server/migrations/20180213070811-update-user.js
@@ -1,0 +1,32 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return [      
+      await queryInterface.changeColumn('Users', 'profileImg', {        
+        type: Sequelize.TEXT('medium'),
+        allowNull: true,        
+      }),
+      
+      await queryInterface.changeColumn('Users','id', {
+        type: Sequelize.UUID,
+        default: Sequelize.UUIDV4
+      }),
+      
+    ]
+    
+  },
+  down: async (queryInterface, Sequelize) => {
+    return [
+      await queryInterface.changeColumn('Users', 'profileImg', {        
+        type: Sequelize.BLOB(),
+        allowNull: true,
+      }),
+
+      await queryInterface.changeColumn('Users', 'id', {
+        type: Sequelize.INTEGER,
+        autoincrement: true
+      }),
+           
+    ]  
+  }    
+};

--- a/server/models/inspiration.js
+++ b/server/models/inspiration.js
@@ -1,26 +1,6 @@
-/*import Sequelize from 'sequelize';
-
-  export const InspirationModel = function(sequelizeDB){
-    const Inspiration = sequelizeDB.define('inspiration', {
-      id: {
-        allowNull: false,
-        primaryKey: true,
-        default: Sequelize.UUIDV4,
-        type: Sequelize.UUIDV4,        
-      },    
-      image: {
-        type: Sequelize.TEXT,
-      },  
-      description: {
-        type: Sequelize.STRING,
-      }  
-  });
-  return Inspiration;
-  } */
-
   import Sequelize from 'sequelize';
 
-  const InspirationModel = function(sequelizeDB){
+  export let InspirationModel = function(sequelizeDB){
     const Inspiration = sequelizeDB.define('inspiration', {
       id: {
         allowNull: false,
@@ -34,8 +14,12 @@
       description: {
         type: Sequelize.STRING,
       }  
-  });
+    });
+    Inspiration.associate = models => {
+      Inspiration.belongsTo(models.User);
+    }
+
   return Inspiration;
   }
 
-  //export default InspirationModel;
+ 

--- a/server/models/inspiration.js
+++ b/server/models/inspiration.js
@@ -1,0 +1,41 @@
+/*import Sequelize from 'sequelize';
+
+  export const InspirationModel = function(sequelizeDB){
+    const Inspiration = sequelizeDB.define('inspiration', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        default: Sequelize.UUIDV4,
+        type: Sequelize.UUIDV4,        
+      },    
+      image: {
+        type: Sequelize.TEXT,
+      },  
+      description: {
+        type: Sequelize.STRING,
+      }  
+  });
+  return Inspiration;
+  } */
+
+  import Sequelize from 'sequelize';
+
+  const InspirationModel = function(sequelizeDB){
+    const Inspiration = sequelizeDB.define('inspiration', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        default: Sequelize.UUIDV4,
+        type: Sequelize.UUIDV4,        
+      },    
+      image: {
+        type: Sequelize.TEXT,
+      },  
+      description: {
+        type: Sequelize.STRING,
+      }  
+  });
+  return Inspiration;
+  }
+
+  //export default InspirationModel;

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -1,6 +1,8 @@
 import Sequelize from 'sequelize';
 import bcrypt from 'bcrypt-nodejs';
 
+const env = process.env.node_env;
+
 // Model definition
 export let UserModel = function(sequalizeDB){
   const User = sequalizeDB.define('user',{
@@ -36,15 +38,22 @@ export let UserModel = function(sequalizeDB){
   };
 
   // Some mock data. If user table exist 'force' equals true will drop it first
-  User.sync({force:false}).then(() => {
-    // Table created
-    /* return User.create({
-      username: "Jilian Carlile",
-      email: "jillian.carlile@fakeEmail.com",
-      password: User.generateHash("1234password"),
-      profileImg: null,
-      bioText: null,
-    }); */
-  });
+  if( env === 'test'){
+    User.sync({force:true}).then(() => {
+      // Table created
+       return User.create({
+        username: "Jilian Carlile",
+        email: "jillian.carlile@fakeEmail.com",
+        password: User.generateHash("1234password"),
+        profileImg: null,
+        bioText: null,
+      }); 
+    });
+  } else {
+    User.sync({force:false}).then(() => {
+      
+    });
+  } 
+ 
   return User
 }

--- a/src/components/Pages/Login.js
+++ b/src/components/Pages/Login.js
@@ -16,15 +16,8 @@ class LoginForm extends React.Component {
           if(user){
             const firstname = user.user.split(" ")[0];
             message.success("Welcome back, " + firstname);
-            let base64image = undefined;
-            // Temp fix until database migration. Need to store profile image as base64 string instead of blob
-            // in db.
-            try{
-              base64image = String.fromCharCode.apply(null, new Uint16Array(user.profileImage.data));
-            }
-            catch(error) {
-              base64image = "https://robohash.org/User";
-            }
+            let base64image = undefined;           
+            base64image = user.profileImage;            
             this.props.dispatch({type:'user/logInUser'});   // antd dva operation to change isLoggedIn state to true
             this.props.dispatch({type:'user/updateProfileImage', payload:base64image})
             this.props.dispatch({type: 'user/updateBioText', payload: user.bioText})


### PR DESCRIPTION
The first database migrations are incorporated into the project. It would have been good to start the model definitions with migrations, but less was understood when the project was started. 

So there are two migration files located in \server\migrations. The first will add an Inspiration table with a one user has many inspirations relationship. The second migration file changes the user table profileImg type from blob to Text('medium').

There was some difficulty getting sequelize to work with our current config.js file. So to get the migrations to work a dbMigrationConfig.json.template file was created. Its a messy fix, we should only have one config file, but it was hard to get it to work any other way.

First run npm install as I had to install sequelize-cli.
Then to run the migration you have to be in the \server folder. The command is `..\node_modules\.bin\sequelize db:migrate`. 


