### PR TITLE
Inspiration post and get

### DIFF
--- a/server/models/inspiration.js
+++ b/server/models/inspiration.js
@@ -13,7 +13,11 @@
       },  
       description: {
         type: Sequelize.STRING,
-      }  
+      },
+      userId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+      },  
     });
     Inspiration.associate = models => {
       Inspiration.belongsTo(models.User);

--- a/server/models/inspiration.js
+++ b/server/models/inspiration.js
@@ -5,8 +5,8 @@
       id: {
         allowNull: false,
         primaryKey: true,
-        default: Sequelize.UUIDV4,
-        type: Sequelize.UUIDV4,        
+        defaultValue: Sequelize.UUIDV4,
+        type: Sequelize.UUID,        
       },    
       image: {
         type: Sequelize.TEXT,

--- a/server/server.js
+++ b/server/server.js
@@ -149,6 +149,22 @@ const env = process.env.node_env;
     }
 ); 
 
+router.get('/inspiration', userAuthenticated,
+  (req, res) => {
+    inspirationModel
+      .findAndCountAll({
+        attributes: ['id','image','description'],
+        where: {
+          userId: req.user.id
+        }
+      }).then(result => {
+        res.status(200).json({inspirations: result.rows});
+      }).catch(error => {
+        res.status(400).send({message:'Bad Request. Inspirations not sent!'})
+      });      
+  }
+);
+
   /**************************************************** */
       
   // Register all routes with api prefix

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import {connectToMysqlDB} from './connectToMysqlDB';
 import {UserModel} from './models/userModel';
+import {InspirationModel} from './models/inspiration';
 import {passportStrat} from '../config/passportStrategy';
 
 export const app = express();
@@ -11,9 +12,10 @@ const session = require('express-session');
 const env = process.env.node_env;
 
 (async function(){
-  let mysqlDB = await connectToMysqlDB()
-  let userModel = await UserModel(mysqlDB.sequalizeDB)
-  let passport = await passportStrat(userModel)
+  let mysqlDB = await connectToMysqlDB();
+  let userModel = await UserModel(mysqlDB.sequalizeDB);  
+  let inspirationModel = await InspirationModel(mysqlDB.sequalizeDB);
+  let passport = await passportStrat(userModel);
 
   app.use(bodyParser.json());
 
@@ -105,7 +107,7 @@ const env = process.env.node_env;
     }
   );
 
-  // Profile routes
+  /************* Profile routes ***********************/
   router.post('/profile', userAuthenticated,
     (req, res) => {         
       let paramToUpdate = Object.keys(req.body)[0];   
@@ -133,6 +135,21 @@ const env = process.env.node_env;
     }
   );
   /*****************************************/   
+
+  /************** Inspiration Routes ********************/
+  router.post('/inspiration', userAuthenticated,
+    (req, res) => {
+     inspirationModel.create({userId:req.user.id, image: req.body.image, description: req.body.description})
+      .then(() => {
+        res.status(200).send({message: 'Inspiration successfully saved!'})
+      }).catch(error => {
+        console.log(error);
+        res.status(406).send({message: 'Inspiration was not saved!'})
+      })
+    }
+); 
+
+  /**************************************************** */
       
   // Register all routes with api prefix
   app.use('/api', router);

--- a/server/server.js
+++ b/server/server.js
@@ -138,10 +138,10 @@ const env = process.env.node_env;
 
   /************** Inspiration Routes ********************/
   router.post('/inspiration', userAuthenticated,
-    (req, res) => {
-     inspirationModel.create({userId:req.user.id, image: req.body.image, description: req.body.description})
-      .then(() => {
-        res.status(200).send({message: 'Inspiration successfully saved!'})
+    (req, res) => {     
+     inspirationModel.create({userId: req.user.id, image: req.body.image, description: req.body.description})      
+      .then((inspiration) => {          
+        res.status(200).send({message: 'Inspiration successfully saved!'})        
       }).catch(error => {
         console.log(error);
         res.status(406).send({message: 'Inspiration was not saved!'})

--- a/src/components/Pages/Profile.js
+++ b/src/components/Pages/Profile.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import dva, { connect } from 'dva';
 import map from './images/map.png';
 import prof_pic from './images/profile_pic.png';
-import {addProfilePhoto, addBioText, getPictures} from '../../userApi';
+import {addProfilePhoto, addBioText, getPictures,getBase64ImgFromUrl, addInspiration} from '../../userApi';
 import {
   Card,
   Upload,
@@ -204,7 +204,7 @@ const ImageSelector = ({imageAttrs,selectImage}) => (
   </div>
 );
 
-class BookmarkInspirtaion extends React.Component {
+class BookmarkInspirtaion extends React.Component {  
   state = {
     loading: false,
     visible: false,
@@ -217,7 +217,14 @@ class BookmarkInspirtaion extends React.Component {
       visible: true,
     });
   }
-  handleOk = () => {
+  handleOk = () => {    
+    addInspiration({image: this.state.selectedImageAttrs.src, description:"Test run"}).then(response => {
+      if ( response ){
+        message.success("Inspiration added!");
+      }  else {
+        message.error("Inspiration was not saved!");
+      }
+    });
     this.setState({ loading: true });
     setTimeout(() => {
       this.setState({ loading: false, visible: false });
@@ -225,11 +232,13 @@ class BookmarkInspirtaion extends React.Component {
   }
   handleCancel = () => {
     this.setState({ visible: false });
-  }
-  selectImage = (src,e) => {
-    console.log("Image selected",src);    
-    this.setState({selectedImageAttrs:{src:src}}, this.setState({imageChosen: true}));
-  }
+  }  
+  selectImage = (src,e) => {        
+    getBase64ImgFromUrl(src).then(result => {
+      this.setState({selectedImageAttrs:{src: result}});
+      this.setState({imageChosen: true});    
+    });
+  } 
   updateImages = (imageAttrs) => {    
     this.setState({imageAttrs: imageAttrs});
   }

--- a/src/userApi.js
+++ b/src/userApi.js
@@ -133,3 +133,33 @@ export function getPictures(url){
   })
   
 };
+
+/********* Add inspiration to database functions *************/
+export function getBase64ImgFromUrl(url) {
+  const proxy = "http://cors-proxy.htmldriven.com/?url=";
+  const result =  fetch(url).then(response => response.blob())
+    .then(async blob => {
+      const base64Url = await getBase64(blob);  
+      return base64Url;
+  
+  })
+  return result;
+}
+
+export function addInspiration(inspiration) {
+  return fetch(`${api}/inspiration`, {
+    ...baseOptions,
+    method: 'POST',
+    body: JSON.stringify({ image: inspiration.image, description: inspiration.description }),
+  })
+    .then(response => {
+      if (response.ok) {
+        return response.json();
+      }
+    })
+    .then(data => data ? data.message : null)
+    .catch(error => {
+      console.log(error);
+    });
+}
+/***************************************************************/

--- a/src/userApi.js
+++ b/src/userApi.js
@@ -163,3 +163,20 @@ export function addInspiration(inspiration) {
     });
 }
 /***************************************************************/
+
+/************* Get Inspirations ********************************/
+export function getInspirations(){
+  return fetch(`${api}/inspiration`, {
+    ...baseOptions,   
+  })
+    .then(response => {
+      if (response.ok) {
+        return response.json();
+      }
+    })
+    .then(data => data ? data : null)
+    .catch(error => {
+      console.log(error);
+    });
+}
+/***************************************************************/


### PR DESCRIPTION
I am finding setting up associations in Sequelize is a bit tricky. They have the belongsTo method that was used in the inspiration.js model, while it creates a "userId" column in the inspiration table it does not add the like to the model. Getting the models and the database to align is tricky with sequelize. 

So you can now post inspiration with a photo only. The description is sending a "test value" as I haven't hooked up the description text yet. 

Also added /inspiration get route and getInspirations function to userApi. 