### PR TITLE
Removed the PrivateRoute component from the profile route 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,7 @@ export const App = connect(({ user, inspiration }) => ({
         <div>
           <Route path="/join" component={WrappedRegistrationForm} />
           <Route path="/login" component={WrappedLoginForm} />
-          <PrivateRoute
+          <Route          
             path="/profile"
             render={() => <ProfilePage appState={props} />}
           />


### PR DESCRIPTION
I added the PrivateRoute component to the profile route and because of the way I am loading state into the profile route its breaking things. For now, I am just removing the custom PrivateRoute component from the profile route to fix things.