### PR TITLE
Added Winston Logger for server side logging. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+api.log*
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.0.17",
     "sequelize": "^4.28.6",
-    "sequelize-cli": "^3.2.0"
+    "sequelize-cli": "^3.2.0",
+    "winston": "^2.4.0"
   },
   "scripts": {
     "start": "cross-env react-scripts start",

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ import {connectToMysqlDB} from './connectToMysqlDB';
 import {UserModel} from '../models/userModel';
 import {InspirationModel} from '../models/inspiration';
 import {passportStrat} from '../config/passportStrategy';
+import logger from './utils/logger';
 
 export const app = express();
 export const httpServer = require('http').createServer(app);
@@ -100,8 +101,8 @@ const env = process.env.node_env;
   );    
 
   router.get('/logout', 
-    (req, res) => {
-      console.log("Logging User out!");
+    (req, res) => {      
+      logger("Logging User out!","info");
       req.logout();
       res.send(200);
     }
@@ -117,7 +118,7 @@ const env = process.env.node_env;
           bioText: req.body[paramToUpdate],
         }).then(() => {                   
           res.status(200).send({message: 'Bio updated successfully!'});
-        }).catch(error => {
+        }).catch(error => {          
           res.status(406).send({message: 'Bio update failed.'});
         })
         
@@ -181,6 +182,7 @@ router.get('/inspiration', userAuthenticated,
   /**********************************************************************/   
   } else {    
     httpServer.listen(port);
+    logger('Api Started','info');    
     console.log('Express api listening on port ' + port );
   }
 })()

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,0 +1,18 @@
+import winston from 'winston';
+
+winston.configure({
+    transports: [
+        new (winston.transports.File) ({ filename: './server/utils/api.log'}),
+        new (winston.transports.Console) (),
+    ]
+});
+
+function logger (args, level){   
+    winston[level](...args);
+
+}
+
+export default logger;
+
+
+


### PR DESCRIPTION
Winston is a more general purpose logger for server-side logs, so I went with it instead of Morgan.
I see Morgan as being more useful as middleware to log the http request/response cycle.

The Winston logger is just logging when the server starts. And the log file is in /server/utils/api.log. I wanted to keep it basic as I am new to logging and wanted to build it up slowly.

I haven't added it yet, but for client-side logging, perhaps log4javascript npm package will be useful.
Here is some articles describing how log4javascript package would work with client-side logging.
https://www.sitepoint.com/logging-errors-client-side-apps/
http://www.aztutorialz.com/how-to-log-client-side-javascript-errors-reactjs/
