### PR TITLE
Refactor code, add react router to route trips

### DIFF
--- a/src/components/Pages/Plan/Itinerary.js
+++ b/src/components/Pages/Plan/Itinerary.js
@@ -1,27 +1,19 @@
 import React from 'react';
 
 import { Button } from 'antd';
+import { BrowserRouter as Router, Route, Link, Switch } from "react-router-dom";
 
 class Itinerary extends React.Component {
-  constructor() {
-    super();
-
-    this.state = {
-      visible: false
-    };
-  }
-
-  hide = () => {
-    this.props.hideTrips(this.props.showTrips)
-  }
 
   render() {
     return (
       <div>
-        <Button onClick = {this.hide}> Go Back to Previous Trips </Button>
         <h1> {this.props.title} </h1>
         <p> {this.props.description} </p>
-        <p> Add Day by Day Activities </p>
+        <p> Add Day by Day Activies </p>
+        <Button>
+          <Link to = {`/plan/`}> Go Back to Previous Trips </Link>
+        </Button>
       </div>
     )
   }

--- a/src/components/Pages/Plan/Plan.js
+++ b/src/components/Pages/Plan/Plan.js
@@ -1,126 +1,19 @@
-import React from 'react';
+import React from 'react'
+import { Switch, Route } from 'react-router-dom'
+import Trips from './Trips'
+import Itinerary from './Itinerary'
 
-import { Button, Row, Col, Modal, Form, Input } from 'antd';
+const Plan = () => (
+  <plan>
+    <Switch>
+      <Route exact path='/plan' component={Trips}/>
+      <Route path='/plan/:number' render={(props) => (
+        <Itinerary {...props}
+          title = 'Itinerary'
+          description = "Description" />
+      )}/>
+    </Switch>
+  </plan>
+)
 
-import PlanCard from "./PlanCard";
-import Itinerary from "./Itinerary"
-
-const { TextArea } = Input;
-
-class Plan extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      title: '',
-      description: '',
-      picture: '',
-      modalVisible: false,
-      data: [],
-      showTrips: true
-    }
-    this.addTrip = this.addTrip.bind(this);
-    this.removeTrip = this.removeTrip.bind(this);
-  }
-
-  handleProp = (prop) => {
-    return (e) => {
-      this.setState({
-        [prop]:e.target.value
-      })
-    }
-  }
-
-  removeTrip = (index) => {
-    this.setState({
-      data: this.state.data.filter((x,i) => i != index)
-    });
-  }
-
-  toggleTrips = () => {
-    const { showTrips } = this.state
-    this.setState({
-      showTrips: !showTrips
-    });
-  }
-
-  showModal = () => {
-    this.setState({
-      modalVisible: true
-    });
-  }
-
-  hideModal = () => {
-    this.setState({
-      modalVisible: false
-    });
-  }
-
-  addTrip = (e) => {
-    e.preventDefault();
-
-    let tripInfo =
-      {
-        title: this.state.title,
-        description: this.state.description,
-        picture: this.state.picture
-      }
-
-    this.setState({
-      modalVisible: false,
-      data: this.state.data.concat(tripInfo),
-      title: '',
-      description: '',
-      picture: ''
-    });
-  }
-
-  render() {
-
-    return (
-      <Row gutter={24}>
-        <p> PLANNING PAGE </p>
-        <Button onClick={this.showModal}> Create a new itinerary </Button>
-        <Modal
-          title="Create a new itinerary"
-          visible={this.state.modalVisible}
-          onOk={this.addTrip}
-          onCancel={this.hideModal}>
-          <Form>
-            <Input
-              placeholder="Add a title" value={this.state.title}
-              onChange={this.handleProp('title').bind(this)} />
-            <Input
-              placeholder="Add picture URL" value={this.state.picture}
-              onChange={this.handleProp('picture').bind(this)} />
-            <TextArea
-              placeholder = "Write a brief description about your trip"
-              value={this.state.description}
-              onChange={this.handleProp('description').bind(this)}
-              rows={4} />
-          </Form>
-        </Modal>
-        <div>
-          {this.state.showTrips ?
-            this.state.data.map((x, i) =>
-              <div key={i}>
-                <PlanCard
-                  data = {x}
-                  remove = {this.removeTrip.bind(this, i)}
-                  title = {x.title}
-                  description = {x.description}
-                  picture = {x.picture}
-                  hideTrips = {this.toggleTrips.bind(this)} />
-              </div> )
-              : <Itinerary
-                  title = 'Title of trip here'
-                  description = 'Description'
-                  hideTrips = {this.toggleTrips.bind(this)} />
-            }
-        </div>
-      </Row>
-    );
-  }
-}
-
-export default Plan;
+export default Plan

--- a/src/components/Pages/Plan/PlanCard.js
+++ b/src/components/Pages/Plan/PlanCard.js
@@ -1,15 +1,16 @@
 import React from 'react';
 
-import Plan from "./Plan"
 import Itinerary from "./Itinerary"
+import Plan from "./Plan"
 
+import { BrowserRouter as Router, Route, Link, Switch } from "react-router-dom";
 import { Card, Col, Button } from 'antd';
 
 const { Meta } = Card;
 
 class PlanCard extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       visible: true
@@ -24,27 +25,27 @@ class PlanCard extends React.Component {
     this.props.remove(this.props.data);
   }
 
-  hide = () => {
-    this.props.hideTrips(this.props.showTrips)
-  }
-
   render() {
     return (
       <div>
         <Col span={8}>
           <Card
             hoverable
-            onClick = {this.hide}
-            style = {{ margin: '5px'}}
+            style = {{ margin: '5px' }}
             title = {this.props.title}
             visible = {this.state.visible}
             cover = {<img src= {this.props.picture} height = '200px' />} >
           <Meta
             description = {this.props.description} />
+            <Button>
+              <Link to = {`/plan/${this.props.number}`}> Edit Trip </Link>
+            </Button>
+            <br/>
+            <Button
+              onClick = {this.delete}
+              type="danger"> Delete Trip
+            </Button>
           </Card>
-          <Button
-            onClick = {this.delete}
-            type="danger"> Delete Trip </Button>
         </Col>
       </div>
     )

--- a/src/components/Pages/Plan/Trips.js
+++ b/src/components/Pages/Plan/Trips.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { BrowserRouter as Router, Route, Link, Switch } from "react-router-dom";
+import { Button, Row, Col, Modal, Form, Input } from 'antd';
+
+import PlanCard from "./PlanCard";
+
+const { TextArea } = Input;
+
+class Trips extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      title: '',
+      description: '',
+      picture: '',
+      modalVisible: false,
+      data: []
+    }
+    this.addTrip = this.addTrip.bind(this);
+    this.removeTrip = this.removeTrip.bind(this);
+  }
+
+  handleProp = (prop) => {
+    return (e) => {
+      this.setState({
+        [prop]: e.target.value
+      })
+    }
+  }
+
+  removeTrip = (index) => {
+    this.setState({
+      data: this.state.data.filter((x,i) => i != index)
+    });
+  }
+
+  showModal = () => {
+    this.setState({
+      modalVisible: true
+    });
+  }
+
+  addTrip = (e) => {
+    e.preventDefault();
+
+    let tripInfo =
+      {
+        title: this.state.title,
+        description: this.state.description,
+        picture: this.state.picture
+      }
+
+    this.setState({
+      modalVisible: false,
+      data: this.state.data.concat(tripInfo),
+      title: '',
+      description: '',
+      picture: ''
+    });
+  }
+
+  render() {
+    return (
+      <Row gutter={24}>
+        <p> PLANNING PAGE </p>
+        <Button onClick={this.showModal}> Create a new itinerary </Button>
+        <Modal
+          title="Create a new itinerary"
+          visible={this.state.modalVisible}
+          onOk={this.addTrip}
+          onCancel={this.hideModal}>
+          <Form>
+            <Input
+              placeholder="Add a title" value={this.state.title}
+              onChange={this.handleProp('title').bind(this)} />
+            <Input
+              placeholder="Add picture URL" value={this.state.picture}
+              onChange={this.handleProp('picture').bind(this)} />
+            <TextArea
+              placeholder = "Write a brief description about your trip"
+              value={this.state.description}
+              onChange={this.handleProp('description').bind(this)}
+              rows={4} />
+          </Form>
+        </Modal>
+        <div>
+          {this.state.data.map((x, i) =>
+            <div key={i}>
+              <PlanCard
+                data = {x}
+                number = {i}
+                remove = {this.removeTrip.bind(this, i)}
+                title = {x.title}
+                description = {x.description}
+                picture = {x.picture} />
+            </div>
+          )}
+        </div>
+      </Row>
+    );
+  }
+}
+
+export default Trips;

--- a/src/components/Pages/Plan/Trips.js
+++ b/src/components/Pages/Plan/Trips.js
@@ -20,7 +20,6 @@ class Trips extends React.Component {
     this.addTrip = this.addTrip.bind(this);
     this.removeTrip = this.removeTrip.bind(this);
   }
-
   handleProp = (prop) => {
     return (e) => {
       this.setState({
@@ -34,10 +33,14 @@ class Trips extends React.Component {
       data: this.state.data.filter((x,i) => i != index)
     });
   }
-
   showModal = () => {
     this.setState({
       modalVisible: true
+    });
+  }
+  hideModal = () => {
+    this.setState({
+      modalVisible: false
     });
   }
 


### PR DESCRIPTION
Starting to add in routing for when a user clicks 'edit trip' in the PlanCard, it will route them to a new page to enter in more detailed information about that specific trip. As of the now that route is going to be number of the current array element ie /plan/0 or /plan/1 etc. For now until I hookup to the backend it will not save the 'cards' if they render a different page. 

Need to find a way to move props (like title, description, and picture) from the PlanCard component to Itinerary component. Have current dummy info in Plan.js file that renders to Itinerary. Any suggestions on how to structure this better would be appreciated